### PR TITLE
Remove --deep option from codesign

### DIFF
--- a/build-macos.sh
+++ b/build-macos.sh
@@ -30,10 +30,8 @@ build_transmission() {
         
         codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app/Contents/Library/QuickLook/QuickLookPlugin.qlgenerator/Contents/MacOS/QuickLookPlugin
         codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" --entitlements ./macosx/QuickLookExtension/QuickLookExtension.entitlements dmg/Transmission.app/Contents/PlugIns/QuickLook/QuickLookExtension.appex/Contents/MacOS/QuickLookExtension
-        codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app/Contents/Frameworks/Sparkle.framework/Versions/A/Resources/Autoupdate.app/Contents/MacOS/Autoupdate
-        codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app/Contents/Frameworks/Sparkle.framework/Versions/A/Resources/Autoupdate.app/Contents/MacOS/fileop
-        codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app/Contents/Frameworks/Sparkle.framework/Versions/A/Resources/Autoupdate.app
-        codesign --force --deep --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app
+        codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app/Contents/Frameworks/Sparkle.framework
+        codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app
         
         spctl -a -v dmg/Transmission.app
         security list-keychains -s login.keychain

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -29,7 +29,7 @@ build_transmission() {
         security list-keychains -s "${KEYCHAIN_NAME}"
         
         codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app/Contents/Library/QuickLook/QuickLookPlugin.qlgenerator/Contents/MacOS/QuickLookPlugin
-        codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" --entitlements ./macosx/QuickLookExtension/QuickLookExtension.entitlements dmg/Transmission.app/Contents/PlugIns/QuickLook/QuickLookExtension.appex/Contents/MacOS/QuickLookExtension
+        codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" --entitlements ./macosx/QuickLookExtension/QuickLookExtension.entitlements dmg/Transmission.app/Contents/PlugIns/QuickLook/QuickLookExtension.appex
         codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app/Contents/Frameworks/Sparkle.framework
         codesign --force --timestamp --options runtime -v -s "${CERT_NAME}" dmg/Transmission.app
         


### PR DESCRIPTION
The deep option is discouraged (https://developer.apple.com/documentation/xcode/creating-distribution-signed-code-for-the-mac#Avoid-deep-code-signing). This requires us to codesign the Sparkle framework directly.

This matches https://github.com/transmission/transmission-release-scripts/pull/6 but points to master